### PR TITLE
Use explicit QML font properties with cross-platform monospace fallback

### DIFF
--- a/src/ui/components/SpectrumView/BandItem.qml
+++ b/src/ui/components/SpectrumView/BandItem.qml
@@ -5,6 +5,8 @@ import SiriusScope 1.0
 Item {
     id: root
 
+    readonly property string monoFontFamily: "Consolas, Monospace"
+
     property int bandId: 0
     property real centerHz: 0
     property real widthHz: 0
@@ -71,7 +73,8 @@ Item {
             anchors.topMargin: 4
             text: "B" + (bandId + 1) + " " + thresholdDb.toFixed(0) + " dB"
             color: enabled ? "#e7eef8" : "#a0a6ad"
-            font: "10px Consolas"
+            font.family: root.monoFontFamily
+            font.pixelSize: 10
         }
 
         MouseArea {
@@ -267,7 +270,8 @@ Item {
             Text {
                 text: "Threshold"
                 color: "#d7dbe2"
-                font: "10px Consolas"
+                font.family: root.monoFontFamily
+                font.pixelSize: 10
             }
 
             Slider {
@@ -299,7 +303,8 @@ Item {
                 Text {
                     text: thresholdDb.toFixed(0) + " dB"
                     color: "#a9b2bd"
-                    font: "10px Consolas"
+                    font.family: root.monoFontFamily
+                    font.pixelSize: 10
                 }
             }
         }

--- a/src/ui/components/SpectrumView/SpectrumView.qml
+++ b/src/ui/components/SpectrumView/SpectrumView.qml
@@ -7,6 +7,8 @@ Item {
     id: root
     focus: true
 
+    readonly property string monoFontFamily: "Consolas, Monospace"
+
     property real minDb: -120
     property real maxDb: 0
     readonly property real viewMinHz: FrequencyViewportModel.viewMinHz
@@ -168,7 +170,7 @@ Item {
                     }
 
                     ctx.fillStyle = "#a5b0bd"
-                    ctx.font = "10px Consolas"
+                    ctx.font = "10px " + root.monoFontFamily
                     ctx.textAlign = "center"
                     ctx.textBaseline = "bottom"
 


### PR DESCRIPTION
### Motivation
- Remove shorthand `font: "..."` usages to make font settings explicit and portable across platforms.
- Ensure a consistent monospace fallback chain so UI labels and canvas text use `Consolas` where available and fall back to a generic monospace.

### Description
- Added a `readonly property string monoFontFamily: "Consolas, Monospace"` to `BandItem.qml` and `SpectrumView.qml` to centralize the monospace fallback.
- Replaced `font: "10px Consolas"` in `src/ui/components/SpectrumView/BandItem.qml` with `font.family: root.monoFontFamily` and `font.pixelSize: 10` at each Text node that used the shorthand.
- Updated the canvas text in `src/ui/components/SpectrumView/SpectrumView.qml` to use `ctx.font = "10px " + root.monoFontFamily` so the same fallback chain applies to canvas-rendered labels.
- Checked `src/ui/components/AntennaIndicator/Indicator.qml` and other priority files and found no remaining `font: "..."` shorthand usages to convert.

### Testing
- Ran `rg -n 'font\s*:\s*"[^"]+"' src/ui/**/*.qml src/ui/**/**/*.qml` and confirmed no remaining shorthand `font: "..."` matches (success).
- Inspected the file diffs to verify the explicit properties and new `monoFontFamily` were added to the two modified files (success).
- Attempted to capture a UI screenshot via a Playwright script, but navigation to `http://127.0.0.1:3000` failed due to no service listening on that port (automated test failed due to environment, not code).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996f7712dd8832792764ac45dcbf150)