### PR TITLE
Add layered architecture scaffolding and modular CMake targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,7 @@ find_package(Qt6 REQUIRED COMPONENTS Quick ShaderTools)
 
 qt_standard_project_setup(REQUIRES 6.8)
 
-qt_add_executable(appSiriusScope
-    src/app/main.cpp
+set(SIRIUSSCOPE_APPLICATION_SOURCES
     src/app/appstate.h
     src/app/appstate.cpp
     src/app/frequencyviewportmodel.h
@@ -26,6 +25,48 @@ qt_add_executable(appSiriusScope
     src/app/waterfallitem.cpp
     src/app/waterfallringbuffer.h
     src/app/waterfallringbuffer.cpp
+)
+
+set(SIRIUSSCOPE_CORE_SOURCES
+    src/core/layer_placeholder.cpp
+)
+
+add_library(siriusscope_core STATIC
+    ${SIRIUSSCOPE_CORE_SOURCES}
+)
+
+target_compile_features(siriusscope_core
+    PUBLIC cxx_std_20
+)
+
+add_library(siriusscope_processing_iface INTERFACE)
+add_library(siriusscope_infrastructure_iface INTERFACE)
+add_library(siriusscope_hardware_iface INTERFACE)
+
+add_library(siriusscope_application STATIC
+    ${SIRIUSSCOPE_APPLICATION_SOURCES}
+)
+
+target_link_libraries(siriusscope_application
+    PUBLIC
+        Qt6::Quick
+        siriusscope_core
+        siriusscope_processing_iface
+        siriusscope_infrastructure_iface
+        siriusscope_hardware_iface
+)
+
+target_compile_features(siriusscope_application
+    PUBLIC cxx_std_20
+)
+
+qt_add_executable(appSiriusScope
+    src/app/main.cpp
+)
+
+target_link_libraries(appSiriusScope
+    PRIVATE
+        siriusscope_application
 )
 
 qt_add_qml_module(appSiriusScope
@@ -61,14 +102,6 @@ set_target_properties(appSiriusScope PROPERTIES
     MACOSX_BUNDLE_SHORT_VERSION_STRING ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}
     MACOSX_BUNDLE TRUE
     WIN32_EXECUTABLE TRUE
-)
-
-target_link_libraries(appSiriusScope
-    PRIVATE Qt6::Quick
-)
-
-target_compile_features(appSiriusScope
-    PRIVATE cxx_std_20
 )
 
 include(GNUInstallDirs)

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -1,0 +1,10 @@
+# Core layer
+
+Core/domain layer scaffold for SiriusScope.
+
+Responsibilities:
+- signal/time/bearing domain models;
+- processing-independent business rules;
+- layer-stable contracts shared by upper/lower layers.
+
+This file is a placeholder for architectural stage 1.1.

--- a/src/core/layer_placeholder.cpp
+++ b/src/core/layer_placeholder.cpp
@@ -1,0 +1,5 @@
+namespace siriusscope::core {
+
+void layerPlaceholderAnchor() {}
+
+} // namespace siriusscope::core

--- a/src/hardware/README.md
+++ b/src/hardware/README.md
@@ -1,0 +1,10 @@
+# Hardware adapter layer
+
+Hardware adapter layer scaffold for SiriusScope.
+
+Responsibilities:
+- UDP/TCP clients and protocol parsers;
+- hardware and simulator adapters behind application interfaces;
+- protocol-version isolation and diagnostics.
+
+This file is a placeholder for architectural stage 1.1.

--- a/src/infrastructure/README.md
+++ b/src/infrastructure/README.md
@@ -1,0 +1,10 @@
+# Infrastructure layer
+
+Infrastructure layer scaffold for SiriusScope.
+
+Responsibilities:
+- storage, settings, logging;
+- binary/archive persistence and rotation;
+- non-domain technical services.
+
+This file is a placeholder for architectural stage 1.1.

--- a/src/processing/README.md
+++ b/src/processing/README.md
@@ -1,0 +1,10 @@
+# Processing layer
+
+Processing layer scaffold for SiriusScope.
+
+Responsibilities:
+- sample validation;
+- aggregation and row preparation;
+- bearing-related calculations built on core contracts.
+
+This file is a placeholder for architectural stage 1.1.


### PR DESCRIPTION
### Motivation

- Prepare an explicit, minimal layered repository layout following the architecture rules so future work can place code into `core`, `processing`, `infrastructure`, and `hardware` without changing public interfaces. 
- Provide a non-invasive CMake-level modularization scaffold to allow gradual migration of sources into per-layer targets while preserving existing QML runtime wiring. 
- Ensure the change is scaffold-only: no domain/processing/storage/hardware logic was implemented or moved into QML.

### Description

- Added layer scaffolding under `src/` with placeholder documentation to make responsibilities explicit: `src/core/README.md`, `src/processing/README.md`, `src/infrastructure/README.md`, and `src/hardware/README.md`.
- Added a minimal compilation anchor for the core layer: `src/core/layer_placeholder.cpp` and introduced CMake targets and source groups in `CMakeLists.txt`: `siriusscope_core` (STATIC), `siriusscope_application` (STATIC), and interface libraries `siriusscope_processing_iface`, `siriusscope_infrastructure_iface`, `siriusscope_hardware_iface` so layers can be populated incrementally.
- Kept runtime and QML wiring unchanged: `qt_add_qml_module` and the QML file list remain on `appSiriusScope`, and `appSiriusScope` is linked through `siriusscope_application` to avoid changing current UI behaviour or introducing QML↔hardware/storage/protocol coupling.

### Testing

- Configuration attempt: ran `cmake -S . -B build/build-codex -DCMAKE_BUILD_TYPE=Debug` which failed in this environment because Qt6 CMake package files were not available (`Qt6Config.cmake` not found), so the project could not be configured here.  
- Build attempt: ran `cmake --build build/build-codex` which could not proceed due to the failed configuration step above.  
- No unit or integration tests were added or executed as this change is scaffold-only; full build and smoke-check should be performed in an environment with Qt6 installed by running `cmake -S . -B build/build-codex -DCMAKE_BUILD_TYPE=Debug` and `cmake --build build/build-codex`, followed by the normal manual UI smoke checks and `ctest --test-dir build/build-codex --output-on-failure` once Qt is available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff138a65c4832788be14239570a14b)